### PR TITLE
Fix a bug in from_env and add more documentation

### DIFF
--- a/discordbot/config.py
+++ b/discordbot/config.py
@@ -4,19 +4,23 @@ import os
 import sys
 
 
-def from_env(name: str, default=None, type_=str):
+def from_env(name: str, *, default=None, optional=False, type_=str):
     """Get a configuration value from the environment"""
 
     if __debug__ and not name.upper():
         raise ValueError("Names of environment variables should be upper case by convention")
 
-    value = type_(os.environ.get(name, default))
+    value = os.getenv(name)
+
     if value is None:
+        if optional:
+            return default
+
         print(
-            "Missing environment variable {0}.\n" +
-            "reate a .env-File containing {0}=<value> to configure it.".format(name),
+            ("Missing environment variable {0}.\n" +
+             "Create a .env-File containing {0}=<value> to configure it.").format(name),
             file=sys.stderr,
         )
         sys.exit(1)
 
-    return value
+    return type_(value)

--- a/discordbot/config.py
+++ b/discordbot/config.py
@@ -5,7 +5,20 @@ import sys
 
 
 def from_env(name: str, *, default=None, optional=False, type_=str):
-    """Get a configuration value from the environment"""
+    """Get a configuration value from the environment
+
+    :param name:
+        The name of the environment variable
+    :param default:
+        The default value which should be used if the variable is not set
+    :param optional:
+        If the default value is None and the variable is not set, return None
+    :param type_:
+        The type of the value
+
+    Example: To get an int from the environment:
+    >>> from_env("SOME_INT", type_=int)
+    """
 
     if __debug__ and not name.upper():
         raise ValueError("Names of environment variables should be upper case by convention")


### PR DESCRIPTION
`from_env` has a bug where it ignores undefined environment variables instead of exiting with an error.
The reason is that the value is first parsed into the requested type before it is checked against `None`:

```python
# from os.environ.get(...), when the environment variable is not set
value = None

# if str is the requested type:
value = str(None) # value is now "None"
```

When checking for `None`:
```python
if value is None:
    # exit with an error
```

is now equivalent to:
```python
if "None" is None:
    # exit with an error
```

This pull request fixes that bug and adds more documentation to `from_env`.